### PR TITLE
제목 커버 배경색 설정 기능 개발

### DIFF
--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -4,6 +4,7 @@ import { commonTheme } from "styles/Theme";
 interface TitleSectionWrapperProps
   extends React.HTMLAttributes<HTMLDivElement> {
   bgImage?: string | null;
+  bgColor?: string | null;
   expanded?: boolean | null;
 }
 
@@ -11,6 +12,7 @@ export const TitleSectionWrapper = styled.div<TitleSectionWrapperProps>`
   width: 100%;
   height: ${({ expanded }) => (expanded ? "100vh" : "450px")};
   border-bottom: 1px solid ${commonTheme.light_gray};
+  background-color: ${({ bgColor }) => bgColor || "trasnparent"};
   background-image: ${({ bgImage }) => (bgImage ? `url(${bgImage})` : "none")};
   background-size: cover;
   background-position: center;

--- a/src/components/Title/TitleSection/TitleSection.tsx
+++ b/src/components/Title/TitleSection/TitleSection.tsx
@@ -3,13 +3,19 @@ import * as S from "./TitleSection.style";
 import TitleToolbar from "../TitleToolbar/TitleToolbar";
 import TitleInput from "../TitleInput/TitleInput";
 import useTitleImageStore from "store/useTitleImageStore";
+import TitleCoverColorSwiper from "../TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper";
 
 export default function TitleSection() {
   const titleImage = useTitleImageStore((state) => state.titleCoverImage);
+  const titleCoverColor = useTitleImageStore((state) => state.titleCoverColor);
   const isTitleImageExpanded = useTitleImageStore((state) => state.isExpanded);
 
   return (
-    <S.TitleSectionWrapper bgImage={titleImage} expanded={isTitleImageExpanded}>
+    <S.TitleSectionWrapper
+      bgImage={titleImage}
+      expanded={isTitleImageExpanded}
+      bgColor={titleCoverColor}
+    >
       <S.TitleTopWrapper>
         <S.TitleMenuWrapper>메뉴바</S.TitleMenuWrapper>
         <S.TitleSaveWrapper>저장</S.TitleSaveWrapper>
@@ -17,6 +23,7 @@ export default function TitleSection() {
       <S.TitleBottomWrapper>
         <TitleToolbar />
         <TitleInput />
+        {titleCoverColor && <TitleCoverColorSwiper />}
       </S.TitleBottomWrapper>
     </S.TitleSectionWrapper>
   );

--- a/src/components/Title/TitleToolbar/TitleToolbar.tsx
+++ b/src/components/Title/TitleToolbar/TitleToolbar.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import * as S from "./TitleToolbar.style";
-import { ImTextColor } from "react-icons/im";
 import { CiTextAlignLeft } from "react-icons/ci";
 import { CiTextAlignCenter } from "react-icons/ci";
 import TitleCoverImageTool from "../TitleTools/TitleCoverImageTool/TitleCoverImageTool";
 import useTitleImageStore from "store/useTitleImageStore";
 import TitleCoverImageActiveTool from "../TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool";
+import TitleCoverColorIcon from "../TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon";
 
 export default function TitleToolbar() {
   const titleImage = useTitleImageStore((state) => state.titleCoverImage);
@@ -13,7 +13,7 @@ export default function TitleToolbar() {
   return (
     <S.TitleToolbarWrapper>
       <TitleCoverImageTool />
-      {!titleImage && <ImTextColor size={25} />}
+      {!titleImage && <TitleCoverColorIcon />}
       <CiTextAlignLeft size={25} />
       {/* <CiTextAlignCenter /> */}
       {titleImage && <TitleCoverImageActiveTool />}

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+import { ImTextColor } from "react-icons/im";
+
+export const ColorIcon = styled(ImTextColor)`
+  cursor: pointer;
+`;

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import * as S from "./TitleCoverColorIcon.style";
+import useTitleImageStore from "store/useTitleImageStore";
+import { titleCoverColors } from "styles/Theme";
+
+export default function TitleCoverColorIcon() {
+  const titleCoverColor = useTitleImageStore((state) => state.titleCoverColor);
+  const setTitleCoverColor = useTitleImageStore(
+    (state) => state.setTitleCoverColor
+  );
+
+  const toggleTitleCoverColor = () => {
+    if (titleCoverColor) setTitleCoverColor(null);
+    if (!titleCoverColor) setTitleCoverColor(titleCoverColors.red);
+  };
+  return <S.ColorIcon size={25} onClick={toggleTitleCoverColor} />;
+}

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.style.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const SwiperContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 50px;
+  padding: 0 120px;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+`;
+export const PrevButton = styled.button`
+  width: 24px;
+  height: 22px;
+  background-image: url("https://t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover_color_arr.png");
+  background-position: 0 0;
+  cursor: pointer;
+`;
+
+export const NextButton = styled.button`
+  width: 24px;
+  height: 22px;
+  background-image: url("https://t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover_color_arr.png");
+  background-position: -28px 0;
+  cursor: pointer;
+`;
+
+export const ColorSelectContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const ColorCircle = styled.div<{ isSelected: boolean }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: ${({ isSelected }) =>
+    isSelected ? "transparent" : "#fff"};
+  opacity: ${({ isSelected }) => (isSelected ? "1" : "0.4")};
+  transition: border 0.3s ease, transform 0.3s ease;
+  border: ${({ isSelected }) => (isSelected ? "1px solid white" : "none")};
+  transform: ${({ isSelected }) => (isSelected ? "scale(1.4)" : "scale(1)")};
+  cursor: pointer;
+`;

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import * as S from "./TitleCoverColorSwiper.style";
+import useTitleImageStore from "store/useTitleImageStore";
+import { titleCoverColors } from "styles/Theme";
+
+const TitleCoverColorSwiper = () => {
+  const currentColor = useTitleImageStore((state) => state.titleCoverColor);
+  const setTitleCoverColor = useTitleImageStore(
+    (state) => state.setTitleCoverColor
+  );
+
+  const colorKeys = Object.keys(titleCoverColors);
+  const currentIndex = colorKeys.indexOf(
+    Object.keys(titleCoverColors).find(
+      (key) => titleCoverColors[key] === currentColor
+    ) || ""
+  );
+
+  const nextSlide = () => {
+    const nextIndex = (currentIndex + 1) % colorKeys.length;
+    setTitleCoverColor(titleCoverColors[colorKeys[nextIndex]]);
+  };
+
+  const prevSlide = () => {
+    const prevIndex = (currentIndex - 1 + colorKeys.length) % colorKeys.length;
+    setTitleCoverColor(titleCoverColors[colorKeys[prevIndex]]);
+  };
+
+  return (
+    <S.SwiperContainer>
+      <S.PrevButton onClick={prevSlide} />
+      <S.ColorSelectContainer>
+        {colorKeys.map((colorKey) => (
+          <S.ColorCircle
+            key={colorKey}
+            isSelected={titleCoverColors[colorKey] === currentColor}
+            onClick={() => setTitleCoverColor(titleCoverColors[colorKey])}
+            color={titleCoverColors[colorKey]}
+          />
+        ))}
+      </S.ColorSelectContainer>
+      <S.NextButton onClick={nextSlide} />
+    </S.SwiperContainer>
+  );
+};
+
+export default TitleCoverColorSwiper;

--- a/src/store/useTitleImageStore.ts
+++ b/src/store/useTitleImageStore.ts
@@ -2,16 +2,28 @@ import { create } from "zustand";
 
 interface StoreProps {
   titleCoverImage: string | null;
+  titleCoverColor: string | null;
   isExpanded: boolean;
 
   setTitleCoverImage: (image: string | null) => void;
+  setTitleCoverColor: (color: string | null) => void;
   setIsExpanded: (expanded: boolean) => void;
 }
 
 const useTitleImageStore = create<StoreProps>((set) => ({
   titleCoverImage: null,
+  titleCoverColor: null,
   isExpanded: false,
-  setTitleCoverImage: (image) => set({ titleCoverImage: image }),
+  setTitleCoverImage: (image) =>
+    set({
+      titleCoverImage: image,
+      titleCoverColor: null,
+    }),
+  setTitleCoverColor: (color) =>
+    set({
+      titleCoverColor: color,
+      titleCoverImage: null,
+    }),
   setIsExpanded: (expanded) => set({ isExpanded: expanded }),
 }));
 

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -20,3 +20,20 @@ export const commonTheme = {
   red: "#FF7C60",
   green: "#67CF56",
 };
+
+type TitleCoverColors = {
+  [key: string]: string;
+};
+
+export const titleCoverColors: TitleCoverColors = {
+  red: "rgb(246, 112, 102)",
+  orange: "rgb(248, 151, 46)",
+  yellow: "rgb(250, 187, 17)",
+  green: "rgb(35, 184, 119)",
+  turquoise: "rgb(0, 198, 190)",
+  blue: "rgb(80, 161, 195)",
+  purple: "rgb(120, 120, 188)",
+  mutedBlue: "rgb(83, 107, 130)",
+  brown: "rgb(169, 120, 87)",
+  black: "rgb(85, 85, 85)",
+};


### PR DESCRIPTION
## 📝 설명
제목 커버 배경색 설정 기능 개발합니다.

## ✅ PR 유형
- [x] 새로운 기능 추가

## 💻 작업 내용
- theme.ts → titleCoverColors 색상 정의
- TitleSectionWrapper bgColor props 추가
- titlecoverColor.ts → titleCoverColor.ts 배경색상지정 관련 로직 추가
- TitleCoverColorSwiper.ts → 배경 색상 지정 swiper 컴포넌트 제작
- 배경색상지정 아이콘 컴포넌트 분리 → TitleCoverColorIcon
- 배경색상 지정 컴포넌트 활성화 처리
