### PR TITLE
제목 컴포넌트 관련 리팩토링

### DIFF
--- a/src/components/Common/ContentEditable/ContentEditable.style.ts
+++ b/src/components/Common/ContentEditable/ContentEditable.style.ts
@@ -6,9 +6,9 @@ interface EditableDivProps extends React.HTMLAttributes<HTMLDivElement> {
   placeholder?: string;
   fontSize: number;
   fontWeight?: "regular" | "medium" | "semiBold" | "bold" | "extraBold";
-  placeholderColor?: string;
-  fontColor?: string;
-  cursorColor?: string;
+  $placeholderColor?: string;
+  $fontColor?: string;
+  $cursorColor?: string;
 }
 
 export const EditableDiv = styled.div<EditableDivProps>`
@@ -21,18 +21,18 @@ export const EditableDiv = styled.div<EditableDivProps>`
   cursor: text;
 
   &:focus {
-    caret-color: ${(props) => props.cursorColor};
+    caret-color: ${(props) => props.$cursorColor};
   }
 
   /* placeholder 스타일 */
   &:empty:before {
     content: attr(placeholder);
-    color: ${(props) => props.placeholderColor};
+    color: ${(props) => props.$placeholderColor};
     display: inline-block;
   }
 
   /* 입력된 텍스트가 있을 때 색상 조정 */
   &[contenteditable="true"]:not(:empty) {
-    color: ${(props) => props.fontColor};
+    color: ${(props) => props.$fontColor};
   }
 `;

--- a/src/components/Common/ContentEditable/ContentEditable.style.ts
+++ b/src/components/Common/ContentEditable/ContentEditable.style.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 import React from "react";
-import { commonTheme } from "styles/Theme";
+import { FONT_WEIGHT } from "styles/Theme";
 
 interface EditableDivProps extends React.HTMLAttributes<HTMLDivElement> {
   placeholder?: string;
   fontSize: number;
+  fontWeight?: "regular" | "medium" | "semiBold" | "bold" | "extraBold";
   placeholderColor?: string;
   fontColor?: string;
   cursorColor?: string;
@@ -13,6 +14,8 @@ interface EditableDivProps extends React.HTMLAttributes<HTMLDivElement> {
 export const EditableDiv = styled.div<EditableDivProps>`
   width: 100%;
   font-size: ${(props) => props.fontSize}px;
+  font-weight: ${({ fontWeight }) =>
+    fontWeight ? FONT_WEIGHT[fontWeight] : FONT_WEIGHT.regular};
   border: none;
   outline: none;
   cursor: text;

--- a/src/components/Common/ContentEditable/ContentEditable.style.ts
+++ b/src/components/Common/ContentEditable/ContentEditable.style.ts
@@ -4,8 +4,8 @@ import { FONT_WEIGHT } from "styles/Theme";
 
 interface EditableDivProps extends React.HTMLAttributes<HTMLDivElement> {
   placeholder?: string;
-  fontSize: number;
-  fontWeight?: "regular" | "medium" | "semiBold" | "bold" | "extraBold";
+  $fontSize: number;
+  $fontWeight?: "regular" | "medium" | "semiBold" | "bold" | "extraBold";
   $placeholderColor?: string;
   $fontColor?: string;
   $cursorColor?: string;
@@ -13,9 +13,9 @@ interface EditableDivProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const EditableDiv = styled.div<EditableDivProps>`
   width: 100%;
-  font-size: ${(props) => props.fontSize}px;
-  font-weight: ${({ fontWeight }) =>
-    fontWeight ? FONT_WEIGHT[fontWeight] : FONT_WEIGHT.regular};
+  font-size: ${({ $fontSize }) => $fontSize}px;
+  font-weight: ${({ $fontWeight }) =>
+    $fontWeight ? FONT_WEIGHT[$fontWeight] : FONT_WEIGHT.regular};
   border: none;
   outline: none;
   cursor: text;

--- a/src/components/Common/ContentEditable/ContentEditable.tsx
+++ b/src/components/Common/ContentEditable/ContentEditable.tsx
@@ -36,7 +36,7 @@ export default function ContentEditable({
       contentEditable
       onInput={handleText}
       placeholder={placeholder}
-      fontSize={fontSize}
+      $fontSize={fontSize}
       $fontColor={fontColor}
       $placeholderColor={placeholderColor}
       $cursorColor={cursorColor}

--- a/src/components/Common/ContentEditable/ContentEditable.tsx
+++ b/src/components/Common/ContentEditable/ContentEditable.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import * as S from "./ContentEditable.style";
-import { commonTheme } from "styles/Theme";
+import { COMMON_THEME } from "styles/Theme";
 
 interface ContentEditableProps {
   placeholder?: string;
   maxLength?: number;
   fontSize?: number;
+  fontWeight?: "regular" | "normal" | "semibold" | "bold" | "extraBold";
   fontColor?: string;
   placeholderColor?: string;
   cursorColor?: string;
@@ -17,9 +18,9 @@ export default function ContentEditable({
   maxLength = 50,
   fontSize = 16,
   onChange,
-  fontColor = commonTheme.black_primary,
-  placeholderColor = commonTheme.gray_primary,
-  cursorColor = commonTheme.black_primary,
+  fontColor = COMMON_THEME.black_primary,
+  placeholderColor = COMMON_THEME.gray_primary,
+  cursorColor = COMMON_THEME.black_primary,
 }: ContentEditableProps) {
   const handleText = (e: React.ChangeEvent<HTMLDivElement>) => {
     const inputText = e.target.innerText || "";

--- a/src/components/Common/ContentEditable/ContentEditable.tsx
+++ b/src/components/Common/ContentEditable/ContentEditable.tsx
@@ -37,9 +37,9 @@ export default function ContentEditable({
       onInput={handleText}
       placeholder={placeholder}
       fontSize={fontSize}
-      fontColor={fontColor}
-      placeholderColor={placeholderColor}
-      cursorColor={cursorColor}
+      $fontColor={fontColor}
+      $placeholderColor={placeholderColor}
+      $cursorColor={cursorColor}
     />
   );
 }

--- a/src/components/Title/TitleInput/TitleInput.style.ts
+++ b/src/components/Title/TitleInput/TitleInput.style.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 interface TitleInputDivProps extends React.HTMLAttributes<HTMLDivElement> {
   align: "left" | "center";
+  hasBackground: boolean;
 }
 
 export const TitleInputWrapper = styled.div<TitleInputDivProps>`
@@ -13,11 +14,20 @@ export const TitleInputWrapper = styled.div<TitleInputDivProps>`
   left: 0;
   width: 100%;
   z-index: 1;
+  transition: all ease-in-out 0.2s;
 
-  ${({ align }) =>
+  ${({ align, hasBackground }) =>
     align === "left" &&
+    !hasBackground &&
     `
     bottom: 50px;
+  `}
+
+  ${({ align, hasBackground }) =>
+    align === "left" &&
+    hasBackground &&
+    `
+    bottom: 70px;
   `}
 
   ${({ align }) =>

--- a/src/components/Title/TitleInput/TitleInput.style.ts
+++ b/src/components/Title/TitleInput/TitleInput.style.ts
@@ -2,8 +2,8 @@ import React from "react";
 import styled from "styled-components";
 
 interface TitleInputDivProps extends React.HTMLAttributes<HTMLDivElement> {
-  align: "left" | "center";
-  hasBackground: boolean;
+  $align: "left" | "center";
+  $hasBackground: boolean;
 }
 
 export const TitleInputWrapper = styled.div<TitleInputDivProps>`
@@ -16,22 +16,22 @@ export const TitleInputWrapper = styled.div<TitleInputDivProps>`
   z-index: 1;
   transition: all ease-in-out 0.2s;
 
-  ${({ align, hasBackground }) =>
-    align === "left" &&
-    !hasBackground &&
+  ${({ $align, $hasBackground }) =>
+    $align === "left" &&
+    !$hasBackground &&
     `
     bottom: 50px;
   `}
 
-  ${({ align, hasBackground }) =>
-    align === "left" &&
-    hasBackground &&
+  ${({ $align, $hasBackground }) =>
+    $align === "left" &&
+    $hasBackground &&
     `
     bottom: 70px;
   `}
 
-  ${({ align }) =>
-    align === "center" &&
+  ${({ $align }) =>
+    $align === "center" &&
     `
     bottom: 50%;
   `}

--- a/src/components/Title/TitleInput/TitleInput.style.ts
+++ b/src/components/Title/TitleInput/TitleInput.style.ts
@@ -14,13 +14,13 @@ export const TitleInputWrapper = styled.div<TitleInputDivProps>`
   left: 0;
   width: 100%;
   z-index: 1;
-  transition: all ease-in-out 0.2s;
 
   ${({ $align, $hasBackground }) =>
     $align === "left" &&
     !$hasBackground &&
     `
     bottom: 50px;
+
   `}
 
   ${({ $align, $hasBackground }) =>
@@ -28,11 +28,14 @@ export const TitleInputWrapper = styled.div<TitleInputDivProps>`
     $hasBackground &&
     `
     bottom: 70px;
+      transition: all ease-in-out 0.2s;
+
   `}
 
   ${({ $align }) =>
     $align === "center" &&
     `
     bottom: 50%;
+    text-align: center;
   `}
 `;

--- a/src/components/Title/TitleInput/TitleInput.tsx
+++ b/src/components/Title/TitleInput/TitleInput.tsx
@@ -13,8 +13,8 @@ export default function TitleInput() {
 
   return (
     <S.TitleInputWrapper
-      align={titleAlign}
-      hasBackground={!!titleImage || !!titleCoverColor}
+      $align={titleAlign}
+      $hasBackground={!!titleImage || !!titleCoverColor}
     >
       <ContentEditable
         placeholder="제목을 입력하세요"

--- a/src/components/Title/TitleInput/TitleInput.tsx
+++ b/src/components/Title/TitleInput/TitleInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import * as S from "./TitleInput.style";
 import ContentEditable from "components/Common/ContentEditable/ContentEditable";
 import useTitleStore from "store/useTitleStore";
-import { commonTheme } from "styles/Theme";
+import { COMMON_THEME } from "styles/Theme";
 
 export default function TitleInput() {
   const [title, setTitle] = useState("");
@@ -18,11 +18,11 @@ export default function TitleInput() {
         fontSize={45}
         onChange={setTitle}
         fontColor={
-          titleImage ? commonTheme.white_primary : commonTheme.black_primary
+          titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }
-        placeholderColor={commonTheme.gray_primary}
+        placeholderColor={COMMON_THEME.gray_primary}
         cursorColor={
-          titleImage ? commonTheme.white_primary : commonTheme.black_primary
+          titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }
       />
       <ContentEditable
@@ -30,11 +30,11 @@ export default function TitleInput() {
         fontSize={16}
         onChange={setSubtitle}
         fontColor={
-          titleImage ? commonTheme.white_primary : commonTheme.black_primary
+          titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }
-        placeholderColor={commonTheme.gray_primary}
+        placeholderColor={COMMON_THEME.gray_primary}
         cursorColor={
-          titleImage ? commonTheme.white_primary : commonTheme.black_primary
+          titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }
       />
     </S.TitleInputWrapper>

--- a/src/components/Title/TitleInput/TitleInput.tsx
+++ b/src/components/Title/TitleInput/TitleInput.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import * as S from "./TitleInput.style";
 import ContentEditable from "components/Common/ContentEditable/ContentEditable";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 import { commonTheme } from "styles/Theme";
 
 export default function TitleInput() {
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
 
-  const titleImage = useTitleImageStore((state) => state.titleCoverImage);
-  const titleAlign = useTitleImageStore((state) => state.alignment);
+  const titleImage = useTitleStore((state) => state.titleCoverImage);
+  const titleAlign = useTitleStore((state) => state.alignment);
 
   return (
     <S.TitleInputWrapper align={titleAlign}>

--- a/src/components/Title/TitleInput/TitleInput.tsx
+++ b/src/components/Title/TitleInput/TitleInput.tsx
@@ -8,10 +8,14 @@ export default function TitleInput() {
   const setTitleText = useTitleStore((state) => state.setTitleText);
   const setSubtitleText = useTitleStore((state) => state.setSubtitleText);
   const titleImage = useTitleStore((state) => state.titleCoverImage);
+  const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
   const titleAlign = useTitleStore((state) => state.alignment);
 
   return (
-    <S.TitleInputWrapper align={titleAlign}>
+    <S.TitleInputWrapper
+      align={titleAlign}
+      hasBackground={!!titleImage || !!titleCoverColor}
+    >
       <ContentEditable
         placeholder="제목을 입력하세요"
         fontSize={45}

--- a/src/components/Title/TitleInput/TitleInput.tsx
+++ b/src/components/Title/TitleInput/TitleInput.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
 import * as S from "./TitleInput.style";
 import ContentEditable from "components/Common/ContentEditable/ContentEditable";
 import useTitleStore from "store/useTitleStore";
 import { COMMON_THEME } from "styles/Theme";
 
 export default function TitleInput() {
-  const [title, setTitle] = useState("");
-  const [subtitle, setSubtitle] = useState("");
-
+  const setTitleText = useTitleStore((state) => state.setTitleText);
+  const setSubtitleText = useTitleStore((state) => state.setSubtitleText);
   const titleImage = useTitleStore((state) => state.titleCoverImage);
   const titleAlign = useTitleStore((state) => state.alignment);
 
@@ -16,7 +15,7 @@ export default function TitleInput() {
       <ContentEditable
         placeholder="제목을 입력하세요"
         fontSize={45}
-        onChange={setTitle}
+        onChange={setTitleText}
         fontColor={
           titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }
@@ -28,7 +27,7 @@ export default function TitleInput() {
       <ContentEditable
         placeholder="소제목을 입력하세요"
         fontSize={16}
-        onChange={setSubtitle}
+        onChange={setSubtitleText}
         fontColor={
           titleImage ? COMMON_THEME.white_primary : COMMON_THEME.black_primary
         }

--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -3,23 +3,24 @@ import { COMMON_THEME } from "styles/Theme";
 
 interface TitleSectionWrapperProps
   extends React.HTMLAttributes<HTMLDivElement> {
-  bgImage?: string | null;
-  bgColor?: string | null;
-  expanded?: boolean | null;
+  $bgImage?: string | null;
+  $bgColor?: string | null;
+  $expanded?: boolean | null;
 }
 
 export const TitleSectionWrapper = styled.div<TitleSectionWrapperProps>`
   width: 100%;
-  height: ${({ expanded }) => (expanded ? "100vh" : "450px")};
+  height: ${({ $expanded }) => ($expanded ? "100vh" : "450px")};
   border-bottom: 1px solid ${COMMON_THEME.light_gray};
-  background-color: ${({ bgColor }) => bgColor || "trasnparent"};
-  background-image: ${({ bgImage }) => (bgImage ? `url(${bgImage})` : "none")};
+  background-color: ${({ $bgColor }) => $bgColor || "trasnparent"};
+  background-image: ${({ $bgImage }) =>
+    $bgImage ? `url(${$bgImage})` : "none"};
   background-size: cover;
   background-position: center;
   position: relative;
   transition: all ease-in-out 0.2s;
-  ${({ bgImage }) =>
-    bgImage &&
+  ${({ $bgImage }) =>
+    $bgImage &&
     `
       &::before {
         content: "";

--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -17,7 +17,7 @@ export const TitleSectionWrapper = styled.div<TitleSectionWrapperProps>`
   background-size: cover;
   background-position: center;
   position: relative;
-
+  transition: all ease-in-out 0.2s;
   ${({ bgImage }) =>
     bgImage &&
     `
@@ -31,7 +31,7 @@ export const TitleSectionWrapper = styled.div<TitleSectionWrapperProps>`
         background-color: rgba(0, 0, 0, 0.3);
         z-index: 1; 
       }
-    `}
+    `};
 `;
 
 export const TitleTopWrapper = styled.div`

--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -49,7 +49,7 @@ export const TitleSaveWrapper = styled.div``;
 
 export const TitleBottomWrapper = styled.div`
   width: 700px;
-  height: 370px;
+  height: calc(100% - 80px);
   margin: auto;
   position: relative;
 `;

--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { commonTheme } from "styles/Theme";
+import { COMMON_THEME } from "styles/Theme";
 
 interface TitleSectionWrapperProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -11,7 +11,7 @@ interface TitleSectionWrapperProps
 export const TitleSectionWrapper = styled.div<TitleSectionWrapperProps>`
   width: 100%;
   height: ${({ expanded }) => (expanded ? "100vh" : "450px")};
-  border-bottom: 1px solid ${commonTheme.light_gray};
+  border-bottom: 1px solid ${COMMON_THEME.light_gray};
   background-color: ${({ bgColor }) => bgColor || "trasnparent"};
   background-image: ${({ bgImage }) => (bgImage ? `url(${bgImage})` : "none")};
   background-size: cover;

--- a/src/components/Title/TitleSection/TitleSection.style.ts
+++ b/src/components/Title/TitleSection/TitleSection.style.ts
@@ -45,7 +45,14 @@ export const TitleTopWrapper = styled.div`
 
 export const TitleMenuWrapper = styled.div``;
 
-export const TitleSaveWrapper = styled.div``;
+export const TitleSaveWrapper = styled.button`
+  border-radius: 15px;
+  width: 66px;
+  height: 30px;
+  border: 1px solid ${COMMON_THEME.gray_primary};
+  font-size: 12px;
+  color: ${COMMON_THEME.dark_gray};
+`;
 
 export const TitleBottomWrapper = styled.div`
   width: 700px;

--- a/src/components/Title/TitleSection/TitleSection.tsx
+++ b/src/components/Title/TitleSection/TitleSection.tsx
@@ -12,9 +12,9 @@ export default function TitleSection() {
 
   return (
     <S.TitleSectionWrapper
-      bgImage={titleImage}
-      expanded={isTitleImageExpanded}
-      bgColor={titleCoverColor}
+      $bgImage={titleImage}
+      $expanded={isTitleImageExpanded}
+      $bgColor={titleCoverColor}
     >
       <S.TitleTopWrapper>
         <S.TitleMenuWrapper>메뉴바</S.TitleMenuWrapper>

--- a/src/components/Title/TitleSection/TitleSection.tsx
+++ b/src/components/Title/TitleSection/TitleSection.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import * as S from "./TitleSection.style";
 import TitleToolbar from "../TitleToolbar/TitleToolbar";
 import TitleInput from "../TitleInput/TitleInput";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 import TitleCoverColorSwiper from "../TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper";
 
 export default function TitleSection() {
-  const titleImage = useTitleImageStore((state) => state.titleCoverImage);
-  const titleCoverColor = useTitleImageStore((state) => state.titleCoverColor);
-  const isTitleImageExpanded = useTitleImageStore((state) => state.isExpanded);
+  const titleImage = useTitleStore((state) => state.titleCoverImage);
+  const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
+  const isTitleImageExpanded = useTitleStore((state) => state.isExpanded);
 
   return (
     <S.TitleSectionWrapper

--- a/src/components/Title/TitleSection/TitleSection.tsx
+++ b/src/components/Title/TitleSection/TitleSection.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import * as S from "./TitleSection.style";
-import TitleToolbar from "../TitleToolbar/TitleToolbar";
-import TitleInput from "../TitleInput/TitleInput";
+import TitleToolbar from "components/Title/TitleToolbar/TitleToolbar";
+import TitleInput from "components/Title/TitleInput/TitleInput";
 import useTitleStore from "store/useTitleStore";
-import TitleCoverColorSwiper from "../TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper";
+import TitleCoverColorSwiper from "components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper";
 
 export default function TitleSection() {
   const titleImage = useTitleStore((state) => state.titleCoverImage);

--- a/src/components/Title/TitleToolbar/TitleToolbar.style.ts
+++ b/src/components/Title/TitleToolbar/TitleToolbar.style.ts
@@ -4,7 +4,7 @@ export const TitleToolbarWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 12px;
+  gap: 16px;
   position: absolute;
   top: 10px;
   right: -15%;

--- a/src/components/Title/TitleToolbar/TitleToolbar.tsx
+++ b/src/components/Title/TitleToolbar/TitleToolbar.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import * as S from "./TitleToolbar.style";
 import TitleCoverImageTool from "../TitleTools/TitleCoverImageTool/TitleCoverImageTool";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 import TitleCoverImageActiveTool from "../TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool";
 import TitleCoverColorIcon from "../TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon";
 import TitleAlignTool from "../TitleTools/TitleAlignTool/TitleAlignTool";
 
 export default function TitleToolbar() {
-  const titleImage = useTitleImageStore((state) => state.titleCoverImage);
+  const titleImage = useTitleStore((state) => state.titleCoverImage);
 
   return (
     <S.TitleToolbarWrapper>

--- a/src/components/Title/TitleToolbar/TitleToolbar.tsx
+++ b/src/components/Title/TitleToolbar/TitleToolbar.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import * as S from "./TitleToolbar.style";
-import TitleCoverImageTool from "../TitleTools/TitleCoverImageTool/TitleCoverImageTool";
+import TitleCoverImageTool from "components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool";
 import useTitleStore from "store/useTitleStore";
-import TitleCoverImageActiveTool from "../TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool";
-import TitleCoverColorIcon from "../TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon";
-import TitleAlignTool from "../TitleTools/TitleAlignTool/TitleAlignTool";
+import TitleCoverImageActiveTool from "components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool";
+import TitleCoverColorIcon from "components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon";
+import TitleAlignTool from "components/Title/TitleTools/TitleAlignTool/TitleAlignTool";
 
 export default function TitleToolbar() {
   const titleImage = useTitleStore((state) => state.titleCoverImage);

--- a/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.style.ts
+++ b/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 interface AlignIcon extends React.HTMLAttributes<HTMLDivElement> {
-  hasCoverBg: boolean;
+  $hasCoverBg: boolean;
 }
 
 export const AlignLeftIcon = styled.div<AlignIcon>`
@@ -9,8 +9,8 @@ export const AlignLeftIcon = styled.div<AlignIcon>`
   height: 25px;
   background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
   background-repeat: no-repeat;
-  background-position: ${({ hasCoverBg }) =>
-    hasCoverBg ? "-29px -82px" : "1px -82px"};
+  background-position: ${({ $hasCoverBg }) =>
+    $hasCoverBg ? "-29px -82px" : "1px -82px"};
   cursor: pointer;
   z-index: 1;
 
@@ -24,8 +24,9 @@ export const AlignCenterIcon = styled.div<AlignIcon>`
   height: 25px;
   background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
   background-repeat: no-repeat;
-  background-position: ${({ hasCoverBg }) =>
-    hasCoverBg ? "-29px -124px" : "1px -124px"};
+  background-position: 1px -124px;
+  background-position: ${({ $hasCoverBg }) =>
+    $hasCoverBg ? "-29px -124px" : "1px -124px"};
   cursor: pointer;
   z-index: 1;
 

--- a/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.style.ts
+++ b/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.style.ts
@@ -1,13 +1,35 @@
 import styled from "styled-components";
-import { CiTextAlignLeft } from "react-icons/ci";
-import { CiTextAlignCenter } from "react-icons/ci";
 
-export const AlignLeftIcon = styled(CiTextAlignLeft)`
+interface AlignIcon extends React.HTMLAttributes<HTMLDivElement> {
+  hasCoverBg: boolean;
+}
+
+export const AlignLeftIcon = styled.div<AlignIcon>`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: ${({ hasCoverBg }) =>
+    hasCoverBg ? "-29px -82px" : "1px -82px"};
   cursor: pointer;
   z-index: 1;
+
+  &:hover {
+    background-position: -59px -82px;
+  }
 `;
 
-export const AlignCenterIcon = styled(CiTextAlignCenter)`
+export const AlignCenterIcon = styled.div<AlignIcon>`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: ${({ hasCoverBg }) =>
+    hasCoverBg ? "-29px -124px" : "1px -124px"};
   cursor: pointer;
   z-index: 1;
+
+  &:hover {
+    background-position: -59px -124px;
+  }
 `;

--- a/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
+++ b/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
@@ -3,6 +3,9 @@ import * as S from "./TitleAlignTool.style";
 import useTitleStore from "store/useTitleStore";
 
 export default function TitleAlignTool() {
+  const titleCoverImage = useTitleStore((state) => state.titleCoverImage);
+  const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
+
   const titleAlign = useTitleStore((state) => state.alignment);
   const setTitleAlign = useTitleStore((state) => state.setAlignment);
 
@@ -12,10 +15,16 @@ export default function TitleAlignTool() {
   return (
     <>
       {titleAlign === "left" && (
-        <S.AlignLeftIcon size={25} onClick={() => handleTitleAlign("center")} />
+        <S.AlignLeftIcon
+          onClick={() => handleTitleAlign("center")}
+          hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+        />
       )}
       {titleAlign === "center" && (
-        <S.AlignCenterIcon size={25} onClick={() => handleTitleAlign("left")} />
+        <S.AlignCenterIcon
+          onClick={() => handleTitleAlign("left")}
+          hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+        />
       )}
     </>
   );

--- a/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
+++ b/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
@@ -17,13 +17,13 @@ export default function TitleAlignTool() {
       {titleAlign === "left" && (
         <S.AlignLeftIcon
           onClick={() => handleTitleAlign("center")}
-          hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+          $hasCoverBg={!!titleCoverImage || !!titleCoverColor}
         />
       )}
       {titleAlign === "center" && (
         <S.AlignCenterIcon
           onClick={() => handleTitleAlign("left")}
-          hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+          $hasCoverBg={!!titleCoverImage || !!titleCoverColor}
         />
       )}
     </>

--- a/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
+++ b/src/components/Title/TitleTools/TitleAlignTool/TitleAlignTool.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import * as S from "./TitleAlignTool.style";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 
 export default function TitleAlignTool() {
-  const titleAlign = useTitleImageStore((state) => state.alignment);
-  const setTitleAlign = useTitleImageStore((state) => state.setAlignment);
+  const titleAlign = useTitleStore((state) => state.alignment);
+  const setTitleAlign = useTitleStore((state) => state.setAlignment);
 
   const handleTitleAlign = (alignType: "left" | "center") => {
     setTitleAlign(alignType);

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 interface ImageColorIconProps extends React.HTMLAttributes<HTMLDivElement> {
-  hasCoverBg: boolean;
+  $hasCoverBg: boolean;
 }
 
 export const ImageColorIcon = styled.div<ImageColorIconProps>`
@@ -9,8 +9,8 @@ export const ImageColorIcon = styled.div<ImageColorIconProps>`
   height: 25px;
   background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
   background-repeat: no-repeat;
-  background-position: ${({ hasCoverBg }) =>
-    hasCoverBg ? "-29px -40px" : "1px -40px"};
+  background-position: ${({ $hasCoverBg }) =>
+    $hasCoverBg ? "-29px -40px" : "1px -40px"};
   cursor: pointer;
   z-index: 1;
 

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.style.ts
@@ -1,6 +1,20 @@
 import styled from "styled-components";
-import { ImTextColor } from "react-icons/im";
 
-export const ColorIcon = styled(ImTextColor)`
+interface ImageColorIconProps extends React.HTMLAttributes<HTMLDivElement> {
+  hasCoverBg: boolean;
+}
+
+export const ImageColorIcon = styled.div<ImageColorIconProps>`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: ${({ hasCoverBg }) =>
+    hasCoverBg ? "-29px -40px" : "1px -40px"};
   cursor: pointer;
+  z-index: 1;
+
+  &:hover {
+    background-position: -59px -40px;
+  }
 `;

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
@@ -11,5 +11,10 @@ export default function TitleCoverColorIcon() {
     if (titleCoverColor) setTitleCoverColor(null);
     if (!titleCoverColor) setTitleCoverColor(TITLE_COVER_COLORS.red);
   };
-  return <S.ColorIcon size={25} onClick={toggleTitleCoverColor} />;
+  return (
+    <S.ImageColorIcon
+      onClick={toggleTitleCoverColor}
+      hasCoverBg={!!titleCoverColor}
+    />
+  );
 }

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import * as S from "./TitleCoverColorIcon.style";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 import { titleCoverColors } from "styles/Theme";
 
 export default function TitleCoverColorIcon() {
-  const titleCoverColor = useTitleImageStore((state) => state.titleCoverColor);
-  const setTitleCoverColor = useTitleImageStore(
-    (state) => state.setTitleCoverColor
-  );
+  const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
+  const setTitleCoverColor = useTitleStore((state) => state.setTitleCoverColor);
 
   const toggleTitleCoverColor = () => {
     if (titleCoverColor) setTitleCoverColor(null);

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as S from "./TitleCoverColorIcon.style";
 import useTitleStore from "store/useTitleStore";
-import { titleCoverColors } from "styles/Theme";
+import { TITLE_COVER_COLORS } from "styles/Theme";
 
 export default function TitleCoverColorIcon() {
   const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
@@ -9,7 +9,7 @@ export default function TitleCoverColorIcon() {
 
   const toggleTitleCoverColor = () => {
     if (titleCoverColor) setTitleCoverColor(null);
-    if (!titleCoverColor) setTitleCoverColor(titleCoverColors.red);
+    if (!titleCoverColor) setTitleCoverColor(TITLE_COVER_COLORS.red);
   };
   return <S.ColorIcon size={25} onClick={toggleTitleCoverColor} />;
 }

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorIcon/TitleCoverColorIcon.tsx
@@ -14,7 +14,7 @@ export default function TitleCoverColorIcon() {
   return (
     <S.ImageColorIcon
       onClick={toggleTitleCoverColor}
-      hasCoverBg={!!titleCoverColor}
+      $hasCoverBg={!!titleCoverColor}
     />
   );
 }

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.style.ts
@@ -33,15 +33,15 @@ export const ColorSelectContainer = styled.div`
   gap: 10px;
 `;
 
-export const ColorCircle = styled.div<{ isSelected: boolean }>`
+export const ColorCircle = styled.div<{ $isSelected: boolean }>`
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background-color: ${({ isSelected }) =>
-    isSelected ? "transparent" : "#fff"};
-  opacity: ${({ isSelected }) => (isSelected ? "1" : "0.4")};
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? "transparent" : "#fff"};
+  opacity: ${({ $isSelected }) => ($isSelected ? "1" : "0.4")};
   transition: border 0.3s ease, transform 0.3s ease;
-  border: ${({ isSelected }) => (isSelected ? "1px solid white" : "none")};
-  transform: ${({ isSelected }) => (isSelected ? "scale(1.4)" : "scale(1)")};
+  border: ${({ $isSelected }) => ($isSelected ? "1px solid white" : "none")};
+  transform: ${({ $isSelected }) => ($isSelected ? "scale(1.4)" : "scale(1)")};
   cursor: pointer;
 `;

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
@@ -31,7 +31,7 @@ const TitleCoverColorSwiper = () => {
         {colorKeys.map((colorKey) => (
           <S.ColorCircle
             key={colorKey}
-            isSelected={TITLE_COVER_COLORS[colorKey] === currentColor}
+            $isSelected={TITLE_COVER_COLORS[colorKey] === currentColor}
             onClick={() => setTitleCoverColor(TITLE_COVER_COLORS[colorKey])}
             color={TITLE_COVER_COLORS[colorKey]}
           />

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
@@ -1,27 +1,27 @@
 import React from "react";
 import * as S from "./TitleCoverColorSwiper.style";
 import useTitleStore from "store/useTitleStore";
-import { titleCoverColors } from "styles/Theme";
+import { TITLE_COVER_COLORS } from "styles/Theme";
 
 const TitleCoverColorSwiper = () => {
   const currentColor = useTitleStore((state) => state.titleCoverColor);
   const setTitleCoverColor = useTitleStore((state) => state.setTitleCoverColor);
 
-  const colorKeys = Object.keys(titleCoverColors);
+  const colorKeys = Object.keys(TITLE_COVER_COLORS);
   const currentIndex = colorKeys.indexOf(
-    Object.keys(titleCoverColors).find(
-      (key) => titleCoverColors[key] === currentColor
+    Object.keys(TITLE_COVER_COLORS).find(
+      (key) => TITLE_COVER_COLORS[key] === currentColor
     ) || ""
   );
 
   const nextSlide = () => {
     const nextIndex = (currentIndex + 1) % colorKeys.length;
-    setTitleCoverColor(titleCoverColors[colorKeys[nextIndex]]);
+    setTitleCoverColor(TITLE_COVER_COLORS[colorKeys[nextIndex]]);
   };
 
   const prevSlide = () => {
     const prevIndex = (currentIndex - 1 + colorKeys.length) % colorKeys.length;
-    setTitleCoverColor(titleCoverColors[colorKeys[prevIndex]]);
+    setTitleCoverColor(TITLE_COVER_COLORS[colorKeys[prevIndex]]);
   };
 
   return (
@@ -31,9 +31,9 @@ const TitleCoverColorSwiper = () => {
         {colorKeys.map((colorKey) => (
           <S.ColorCircle
             key={colorKey}
-            isSelected={titleCoverColors[colorKey] === currentColor}
-            onClick={() => setTitleCoverColor(titleCoverColors[colorKey])}
-            color={titleCoverColors[colorKey]}
+            isSelected={TITLE_COVER_COLORS[colorKey] === currentColor}
+            onClick={() => setTitleCoverColor(TITLE_COVER_COLORS[colorKey])}
+            color={TITLE_COVER_COLORS[colorKey]}
           />
         ))}
       </S.ColorSelectContainer>

--- a/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
+++ b/src/components/Title/TitleTools/TitleCoverColor/TitleCoverColorSwiper/TitleCoverColorSwiper.tsx
@@ -1,14 +1,11 @@
-import React, { useState } from "react";
-import styled from "styled-components";
+import React from "react";
 import * as S from "./TitleCoverColorSwiper.style";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 import { titleCoverColors } from "styles/Theme";
 
 const TitleCoverColorSwiper = () => {
-  const currentColor = useTitleImageStore((state) => state.titleCoverColor);
-  const setTitleCoverColor = useTitleImageStore(
-    (state) => state.setTitleCoverColor
-  );
+  const currentColor = useTitleStore((state) => state.titleCoverColor);
+  const setTitleCoverColor = useTitleStore((state) => state.setTitleCoverColor);
 
   const colorKeys = Object.keys(titleCoverColors);
   const currentIndex = colorKeys.indexOf(

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActive.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActive.style.ts
@@ -1,6 +1,8 @@
 import styled from "styled-components";
-import { FaRegTrashCan } from "react-icons/fa6";
-import { RiExpandHeightFill } from "react-icons/ri";
+
+interface ExpandIconProps extends React.HTMLAttributes<HTMLDivElement> {
+  expanded?: boolean | null;
+}
 
 export const IconWrapper = styled.div`
   display: flex;
@@ -9,12 +11,32 @@ export const IconWrapper = styled.div`
   gap: 12px;
 `;
 
-export const ExpandIcon = styled(RiExpandHeightFill)`
+export const ExpandIcon = styled.div<ExpandIconProps>`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: ${({ expanded }) =>
+    expanded ? "-29px -166px" : "-29px -208px"};
   cursor: pointer;
   z-index: 1;
+
+  &:hover {
+    background-position: ${({ expanded }) =>
+      expanded ? "-59px -166px" : "-59px -208px"};
+  }
 `;
 
-export const TrashIcon = styled(FaRegTrashCan)`
+export const TrashIcon = styled.div`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: -29px -250px;
   cursor: pointer;
   z-index: 1;
+
+  &:hover {
+    background-position: -59px -250px;
+  }
 `;

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActive.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActive.style.ts
@@ -1,14 +1,14 @@
 import styled from "styled-components";
 
 interface ExpandIconProps extends React.HTMLAttributes<HTMLDivElement> {
-  expanded?: boolean | null;
+  $expanded?: boolean | null;
 }
 
 export const IconWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 `;
 
 export const ExpandIcon = styled.div<ExpandIconProps>`
@@ -16,14 +16,14 @@ export const ExpandIcon = styled.div<ExpandIconProps>`
   height: 25px;
   background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
   background-repeat: no-repeat;
-  background-position: ${({ expanded }) =>
-    expanded ? "-29px -166px" : "-29px -208px"};
+  background-position: ${({ $expanded }) =>
+    $expanded ? "-29px -166px" : "-29px -208px"};
   cursor: pointer;
   z-index: 1;
 
   &:hover {
-    background-position: ${({ expanded }) =>
-      expanded ? "-59px -166px" : "-59px -208px"};
+    background-position: ${({ $expanded }) =>
+      $expanded ? "-59px -166px" : "-59px -208px"};
   }
 `;
 

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
@@ -10,6 +10,7 @@ export default function TitleCoverImageActiveTool() {
 
   const deleteTitleImage = () => {
     setTitleImage(null);
+    setImageExpanded(false);
   };
 
   const expandImage = () => {

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import * as S from "./TitleCoverImageActive.style";
 
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 
 export default function TitleCoverImageActiveTool() {
-  const setTitleImage = useTitleImageStore((state) => state.setTitleCoverImage);
-  const setImageExpanded = useTitleImageStore((state) => state.setIsExpanded);
-  const isTitleImageExpanded = useTitleImageStore((state) => state.isExpanded);
+  const setTitleImage = useTitleStore((state) => state.setTitleCoverImage);
+  const setImageExpanded = useTitleStore((state) => state.setIsExpanded);
+  const isTitleImageExpanded = useTitleStore((state) => state.isExpanded);
 
   const deleteTitleImage = () => {
     setTitleImage(null);

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
@@ -19,7 +19,7 @@ export default function TitleCoverImageActiveTool() {
 
   return (
     <S.IconWrapper>
-      <S.ExpandIcon expanded={isTitleImageExpanded} onClick={expandImage} />
+      <S.ExpandIcon $expanded={isTitleImageExpanded} onClick={expandImage} />
       <S.TrashIcon onClick={deleteTitleImage} />
     </S.IconWrapper>
   );

--- a/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageActiveTool/TitleCoverImageActiveTool.tsx
@@ -19,8 +19,8 @@ export default function TitleCoverImageActiveTool() {
 
   return (
     <S.IconWrapper>
-      <S.ExpandIcon size={25} onClick={expandImage} />
-      <S.TrashIcon size={25} onClick={deleteTitleImage} />
+      <S.ExpandIcon expanded={isTitleImageExpanded} onClick={expandImage} />
+      <S.TrashIcon onClick={deleteTitleImage} />
     </S.IconWrapper>
   );
 }

--- a/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.style.ts
@@ -1,5 +1,9 @@
+import React from "react";
 import styled from "styled-components";
-import { PiImageThin } from "react-icons/pi";
+
+interface ImageInputIconProps extends React.HTMLAttributes<HTMLDivElement> {
+  hasCoverBg: boolean;
+}
 
 export const ImageInputWrapper = styled.div`
   z-index: 1;
@@ -9,7 +13,17 @@ export const ImageFileInput = styled.input`
   display: none;
 `;
 
-export const ImageInputIcon = styled(PiImageThin)`
+export const ImageInputIcon = styled.div<ImageInputIconProps>`
+  width: 25px;
+  height: 25px;
+  background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
+  background-repeat: no-repeat;
+  background-position: ${({ hasCoverBg }) =>
+    hasCoverBg ? "-29px 2px" : "1px 2px"};
   cursor: pointer;
   z-index: 1;
+
+  &:hover {
+    background-position: -59px 2px;
+  }
 `;

--- a/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.style.ts
+++ b/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.style.ts
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 interface ImageInputIconProps extends React.HTMLAttributes<HTMLDivElement> {
-  hasCoverBg: boolean;
+  $hasCoverBg: boolean;
 }
 
 export const ImageInputWrapper = styled.div`
@@ -18,8 +18,8 @@ export const ImageInputIcon = styled.div<ImageInputIconProps>`
   height: 25px;
   background-image: url(//t1.daumcdn.net/brunch/static/img/help/pc/editor/btn_cover.png);
   background-repeat: no-repeat;
-  background-position: ${({ hasCoverBg }) =>
-    hasCoverBg ? "-29px 2px" : "1px 2px"};
+  background-position: ${({ $hasCoverBg }) =>
+    $hasCoverBg ? "-29px 2px" : "1px 2px"};
   cursor: pointer;
   z-index: 1;
 

--- a/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import * as S from "./TitleCoverImageTool.style";
-import useTitleImageStore from "store/useTitleImageStore";
+import useTitleStore from "store/useTitleStore";
 
 export default function TitleCoverImageTool() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const setTitleImage = useTitleImageStore((state) => state.setTitleCoverImage);
+  const setTitleImage = useTitleStore((state) => state.setTitleCoverImage);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
@@ -4,6 +4,8 @@ import useTitleStore from "store/useTitleStore";
 
 export default function TitleCoverImageTool() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const titleCoverImage = useTitleStore((state) => state.titleCoverImage);
+  const titleCoverColor = useTitleStore((state) => state.titleCoverColor);
   const setTitleImage = useTitleStore((state) => state.setTitleCoverImage);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -29,7 +31,10 @@ export default function TitleCoverImageTool() {
         ref={fileInputRef}
         onChange={handleFileChange}
       />
-      <S.ImageInputIcon size={25} onClick={handleIconClick} />
+      <S.ImageInputIcon
+        onClick={handleIconClick}
+        hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+      />
     </S.ImageInputWrapper>
   );
 }

--- a/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
+++ b/src/components/Title/TitleTools/TitleCoverImageTool/TitleCoverImageTool.tsx
@@ -33,7 +33,7 @@ export default function TitleCoverImageTool() {
       />
       <S.ImageInputIcon
         onClick={handleIconClick}
-        hasCoverBg={!!titleCoverImage || !!titleCoverColor}
+        $hasCoverBg={!!titleCoverImage || !!titleCoverColor}
       />
     </S.ImageInputWrapper>
   );

--- a/src/store/useTitleStore.ts
+++ b/src/store/useTitleStore.ts
@@ -12,7 +12,7 @@ interface StoreProps {
   setAlignment: (alignment: "left" | "center") => void;
 }
 
-const useTitleImageStore = create<StoreProps>((set) => ({
+const useTitleStore = create<StoreProps>((set) => ({
   titleCoverImage: null,
   titleCoverColor: null,
   isExpanded: false,
@@ -31,4 +31,4 @@ const useTitleImageStore = create<StoreProps>((set) => ({
   setAlignment: (alignment) => set({ alignment }),
 }));
 
-export default useTitleImageStore;
+export default useTitleStore;

--- a/src/store/useTitleStore.ts
+++ b/src/store/useTitleStore.ts
@@ -1,11 +1,15 @@
 import { create } from "zustand";
 
 interface StoreProps {
+  titleText: string;
+  subtitleText: string;
   titleCoverImage: string | null;
   titleCoverColor: string | null;
   isExpanded: boolean;
   alignment: "left" | "center";
 
+  setTitleText: (text: string) => void;
+  setSubtitleText: (text: string) => void;
   setTitleCoverImage: (image: string | null) => void;
   setTitleCoverColor: (color: string | null) => void;
   setIsExpanded: (expanded: boolean) => void;
@@ -13,10 +17,20 @@ interface StoreProps {
 }
 
 const useTitleStore = create<StoreProps>((set) => ({
+  titleText: "",
+  subtitleText: "",
   titleCoverImage: null,
   titleCoverColor: null,
   isExpanded: false,
   alignment: "left",
+  setTitleText: (text) =>
+    set({
+      titleText: text,
+    }),
+  setSubtitleText: (text) =>
+    set({
+      titleText: text,
+    }),
   setTitleCoverImage: (image) =>
     set({
       titleCoverImage: image,

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -16,6 +16,7 @@ export const COMMON_THEME = {
   white_primary: "#FAFAFA",
   gray_primary: "#ccc",
   light_gray: "#eee",
+  dark_gray: "#666",
   red: "#FF7C60",
   green: "#67CF56",
 };

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -1,18 +1,17 @@
-export const device = {
+export const DEVICE = {
   tablet: `(max-width: 768px)`,
   laptop: `(max-width: 1024px)`,
 };
 
-export const fontWeight = {
+export const FONT_WEIGHT = {
   regular: 400,
   medium: 500,
   semiBold: 600,
   bold: 700,
   extraBold: 800,
-  black: 900,
 };
 
-export const commonTheme = {
+export const COMMON_THEME = {
   black_primary: "#333333",
   white_primary: "#FAFAFA",
   gray_primary: "#ccc",
@@ -25,7 +24,7 @@ type TitleCoverColors = {
   [key: string]: string;
 };
 
-export const titleCoverColors: TitleCoverColors = {
+export const TITLE_COVER_COLORS: TitleCoverColors = {
   red: "rgb(246, 112, 102)",
   orange: "rgb(248, 151, 46)",
   yellow: "rgb(250, 187, 17)",


### PR DESCRIPTION
## 📝 설명
제목 관련 컴포넌트를 리팩토링 합니다.

## ✅ PR 유형
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정 / 삭제

## 💻 작업 내용
- 제목 전역 상태 store 이름 변경
    - useTitleImageStore → useTitleStore
- 이미지 expand 했을 때, titleInput 위치 조정
- Theme 상수 변수 네이밍 규칙 변경
- ContentEditable 컴포넌트 fontWeight Props 추가 → 제목 input fontWeight 조정
- 저장 버튼 스타일링
- 제목 및 소제목 상태관리 추가
- TitleSection transition 적용
- 이미지 및 배경색 지정 시 하단 공백 추가
- 아이콘들 정리 작업
- warning message 사항들 수정
    - styled component props $ prefix 추가
- 경로 정리
